### PR TITLE
dont break test

### DIFF
--- a/spec/feature/registration_integration_spec.rb
+++ b/spec/feature/registration_integration_spec.rb
@@ -67,4 +67,4 @@ RSpec.describe 'Signing up with Form', type: :system do
 #     #expect(page).to have_content('Terri')
 #     @member2.reload
 #     expect(@member2.first_name).to eq('Terri')
-#   end
+end 


### PR DESCRIPTION
During last merge to test, this integration spec test broke it. Recommented required line back in